### PR TITLE
Use official repo on git.suyu.dev

### DIFF
--- a/suyu.nix
+++ b/suyu.nix
@@ -5,12 +5,13 @@ in
 pkgs.stdenv.mkDerivation {
   pname = "suyu";
   version = "unstable-2024-03-10";
-  src = pkgs.fetchFromGitLab {
-    owner = "suyu-emu";
+  src = pkgs.fetchFromGitea {
+    owner = "suyu";
     repo = "suyu";
     rev = "5e9a855f1ef305d1cb2ec104fbc4347df6a344e1";
     hash = "sha256-mkj7bw5DjFvmOhTIJlFZYHxgRED0PHjzDLIQ6o/WMlY=";
     fetchSubmodules = true;
+    domain = "git.suyu.dev";
   };
 
   nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
Suyu's repo on gitlab.com has been taken offline [because of a DMCA takedown request](https://overkill.wtf/suyu-emulator-removed-from-gitlab/), which causes this to fail building, but they're still hosting [a repo on `git.suyu.dev`](https://git.suyu.dev/suyu/suyu), so this PR changes the derivation to use this repo instead.